### PR TITLE
Change augeas write option in default configuration

### DIFF
--- a/src/fty-config.cfg.in
+++ b/src/fty-config.cfg.in
@@ -24,7 +24,7 @@ available-features
 
 augeas
     lensPath = /usr/share/fty/lenses/
-    augeasOptions = AUG_NONE # Values availabes separate by '|' AUG_NONE AUG_TRACE_MODULE_LOADING AUG_SAVE_BACKUP
+    augeasOptions = AUG_SAVE_BACKUP # Values availabes separate by '|' AUG_NONE AUG_TRACE_MODULE_LOADING AUG_SAVE_BACKUP
 
 config
     version = 1.0 # Config version.


### PR DESCRIPTION
By default, Augeas options field was set to `AUG_NONE`, which were creating issues with the write operation.

Changing to `AUG_SAVE_BACKUP` seems to fix the issue

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>