### PR TITLE
IPMPROG-4347 - handle new data 2.0 format (bulk save & restore)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ etn_target(exe ${PROJECT_NAME}
         src/fty-config.cc
         src/fty_config_manager.cc
         src/fty_config_manager.h
+        src/file.cc
+        src/file.h
     FLAGS
         -Wno-disabled-macro-expansion
     USES

--- a/fty-config.cfg.in
+++ b/fty-config.cfg.in
@@ -9,7 +9,7 @@ server
 srr-msg-bus
     endpoint = ipc://@/malamute             #   Malamute endpoint
     address = srr-agent                     #   Agent address
-    queueName = ETN.Q.IPMCORE.CONFIG           # Srr queue name for all incoming request.
+    queueName = ETN.Q.IPMCORE.CONFIG        #   Srr queue name for all incoming request.
 
 available-features
     monitoring = /etc/fty-nut/fty-nut.cfg
@@ -17,14 +17,14 @@ available-features
     automation-settings = /etc/fty/etn-automation.cfg
     user-session = /etc/fty/fty-session.cfg
     discovery = /etc/fty-discovery/fty-discovery.cfg
-    network = /etc/network/interfaces
-    network-agent-settings = /var/lib/fty/etn-ipm2-network/etn-ipm2-network.json
-    network-host-name = /etc/hostname
     etn-mass-management = /var/lib/fty/etn-mass-management/settings.cfg
+    network = /etc/network/interfaces
+    network-host-name = /etc/hostname
+    network-agent-settings = /var/lib/fty/etn-ipm2-network/etn-ipm2-network.json
 
 augeas
     lensPath = /usr/share/fty/lenses/
     augeasOptions = AUG_SAVE_BACKUP # Values availabes separate by '|' AUG_NONE AUG_TRACE_MODULE_LOADING AUG_SAVE_BACKUP
 
 config
-    version = 1.0 # Config version.
+    version = 1.0 # Config version

--- a/src/file.cc
+++ b/src/file.cc
@@ -1,0 +1,156 @@
+/*  =========================================================================
+    Copyright (C) 2014 - 2020 Eaton
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    =========================================================================
+*/
+
+/** tools to handle file save & restore (bulk save & restore) */
+
+#include "file.h"
+#include <fty_log.h>
+#include <cxxtools/base64codec.h>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <fstream>
+
+// read fileName, returns char* buffer of size bytes
+// returned ptr must be freed by caller
+static char* s_fileRead(const std::string& fileName, size_t& size)
+{
+    char* buffer = nullptr;
+    try {
+        std::ifstream is(fileName, std::ios::in | std::ios::binary);
+        if (is.is_open()) {
+            is.seekg(0, is.end);
+            size_t fSize = size_t(is.tellg());
+            is.seekg(0, is.beg);
+            if (fSize != 0) {
+                buffer = static_cast<char*>(malloc(sizeof(char) * (fSize + 1)));
+                if (!buffer) {
+                    throw std::runtime_error("malloc() failed");
+                }
+                memset(buffer, 0, fSize + 1);
+                is.read(buffer, std::streamsize(fSize));
+            }
+            is.close();
+            size = fSize;
+            return buffer;
+        }
+    }
+    catch (const std::exception& e) {
+        logError("{}", e.what());
+    }
+
+    if (buffer)
+        { free(buffer); }
+
+    size = 0;
+    return nullptr;
+}
+
+// write char* buffer of size bytes in fileName
+// returns 0 if ok, else <0
+static int s_fileWrite(const std::string& fileName, const char* buffer, size_t size)
+{
+    try {
+        std::ofstream os(fileName, std::ios::out | std::ios::binary);
+        if (buffer && (size != 0)) {
+            os.write(buffer, std::streamsize(size));
+        }
+        os.close();
+        return 0;
+    }
+    catch (const std::exception& e) {
+        logError("{}", e.what());
+    }
+    return -1;
+}
+
+// read fileName content to b64 encoded
+// returns 0 if ok (b64 is set), else <0
+int fileReadToBase64(const std::string& fileName, std::string& b64)
+{
+    b64.clear();
+
+    char* buffer = nullptr;
+    try {
+        size_t size = 0;
+        buffer = s_fileRead(fileName, size);
+        if (buffer && (size != 0)) {
+            b64 = cxxtools::Base64Codec::encode(buffer, unsigned(size));
+        }
+        if (buffer)
+            { free(buffer); }
+        return 0;
+    }
+    catch (const std::exception& e) {
+        logError("{}", e.what());
+    }
+
+    if (buffer)
+        { free(buffer); }
+    return -1;
+}
+
+// write fileName content from b64 decoded
+// returns 0 if ok, else <0
+int fileRestoreFromBase64(const std::string& fileName, const std::string& b64)
+{
+    try {
+        logDebug("fileName: {}", fileName);
+        logDebug("b64: {}", b64);
+
+        std::string buffer;
+        if (!b64.empty()) {
+            buffer = cxxtools::Base64Codec::decode(b64);
+        }
+        //logDebug("buffer: {}", buffer);
+        logDebug("buffer size: {}", buffer.size());
+
+        int r = s_fileWrite(fileName, buffer.c_str(), buffer.size());
+        if (r != 0) {
+            throw std::runtime_error("s_fileWrite() failed");
+        }
+        return 0;
+    }
+    catch (const std::exception& e) {
+        logError("{}", e.what());
+    }
+    return -1;
+}
+
+//DBG, dump file content
+void fileDumpToConsole(const std::string& fileName, const std::string& msg)
+{
+    if (!ftylog_isLogDebug(ftylog_getInstance()))
+        return; // debug only
+
+    try {
+        logDebug("{}{}", msg, fileName);
+        std::ifstream is(fileName, std::ifstream::in);
+        if (is.is_open()) {
+            std::string line;
+            while (std::getline(is, line)) {
+                logDebug("{}", line);
+            }
+            is.close();
+        }
+    }
+    catch (const std::exception& e) {
+        logDebug("fileDumpToConsole failed ({}, e: {})", fileName, e.what());
+    }
+}

--- a/src/file.h
+++ b/src/file.h
@@ -1,0 +1,33 @@
+/*  =========================================================================
+    Copyright (C) 2014 - 2020 Eaton
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    =========================================================================
+*/
+
+#pragma once
+
+#include <string>
+
+/// read fileName content to b64 encoded
+/// returns 0 if ok (b64 is set), else <0
+int fileReadToBase64(const std::string& fileName, std::string& b64);
+
+/// write fileName content from b64 decoded
+/// returns 0 if ok, else <0
+int fileRestoreFromBase64(const std::string& fileName, const std::string& b64);
+
+//dump fileName to console, log debug only
+void fileDumpToConsole(const std::string& fileName, const std::string& msg = "");

--- a/src/fty-config.cc
+++ b/src/fty-config.cc
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
     paramsConfig[AUGEAS_LENS_PATH] = "/usr/share/fty/lenses/";
     paramsConfig[AUGEAS_OPTIONS]   = AUG_NONE;
     // version
-    paramsConfig[CONFIG_VERSION_KEY] = ACTIVE_VERSION;
+    paramsConfig[CONFIG_VERSION_KEY] = CONFIG_VERSION;
 
     if (config_file) {
         log_debug((AGENT_NAME + std::string(": loading configuration file from ") + config_file).c_str());
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
         paramsConfig[AUGEAS_LENS_PATH] = config.getEntry("augeas/lensPath", "/usr/share/fty/lenses/");
         paramsConfig[AUGEAS_OPTIONS]   = config.getEntry("augeas/augeasOptions", "0");
         // version
-        paramsConfig[CONFIG_VERSION_KEY] = config.getEntry("config/version", ACTIVE_VERSION);
+        paramsConfig[CONFIG_VERSION_KEY] = config.getEntry("config/version", CONFIG_VERSION);
     }
 
     if (verbose) {

--- a/src/fty-config.cc
+++ b/src/fty-config.cc
@@ -22,21 +22,27 @@
 
 #include "fty-config.h"
 #include "fty_config_manager.h"
-#include <augeas.h>
-#include <condition_variable>
-#include <csignal>
 #include <fty_common_mlm_zconfig.h>
 #include <fty_log.h>
+#include <augeas.h>
+
+#include <condition_variable>
+#include <csignal>
 #include <map>
 #include <mutex>
 #include <sstream>
 
-// functions
-
-void                           usage();
 static bool                    g_exit = false;
 static std::condition_variable g_cv;
 static std::mutex              g_cvMutex;
+
+static void usage()
+{
+    puts((AGENT_NAME + std::string(" [options] ...")).c_str());
+    puts("  -v|--verbose        verbose test output");
+    puts("  -h|--help           this information");
+    puts("  -c|--config         path to config file");
+}
 
 static void sigHandler(int)
 {
@@ -67,21 +73,18 @@ static void setSignalHandler()
 
 int main(int argc, char* argv[])
 {
-    using Parameters = std::map<std::string, std::string>;
-    Parameters paramsConfig;
-
     // Set signal handler
     setSignalHandler();
     // Set terminate pg handler
     std::set_terminate(terminateHandler);
 
-    ftylog_setInstance(AGENT_NAME, "");
+    ftylog_setInstance(AGENT_NAME, FTY_COMMON_LOGGING_DEFAULT_CFG);
 
-    int   argn;
     char* config_file = nullptr;
     bool  verbose     = false;
+
     // Parse command line
-    for (argn = 1; argn < argc; argn++) {
+    for (int argn = 1; argn < argc; argn++) {
         char* param = nullptr;
         if (argn < argc - 1)
             param = argv[argn + 1];
@@ -99,6 +102,8 @@ int main(int argc, char* argv[])
     }
 
     // Default configuration.
+    std::map<std::string, std::string> paramsConfig;
+
     paramsConfig[ENDPOINT_KEY]   = DEFAULT_ENDPOINT;
     paramsConfig[AGENT_NAME_KEY] = AGENT_NAME;
     paramsConfig[QUEUE_NAME_KEY] = MSG_QUEUE_NAME;
@@ -144,8 +149,8 @@ int main(int argc, char* argv[])
     }
 
     if (verbose) {
-        ftylog_setVeboseMode(ftylog_getInstance());
-        log_trace("Verbose mode OK");
+        ftylog_setVerboseMode(ftylog_getInstance());
+        log_trace("Set verbose mode");
     }
 
     log_info((AGENT_NAME + std::string(" starting")).c_str());
@@ -163,12 +168,4 @@ int main(int argc, char* argv[])
 
     // Exit application
     return EXIT_SUCCESS;
-}
-
-void usage()
-{
-    puts((AGENT_NAME + std::string(" [options] ...")).c_str());
-    puts("  -v|--verbose        verbose test output");
-    puts("  -h|--help           this information");
-    puts("  -c|--config         path to config file");
 }

--- a/src/fty-config.h
+++ b/src/fty-config.h
@@ -21,15 +21,16 @@
 
 #pragma once
 
-//  Add your own public definitions here, if you need them
-constexpr auto AGENT_NAME_KEY            = "agentName";
-constexpr auto AGENT_NAME                = "fty-config";
-constexpr auto ENDPOINT_KEY              = "endPoint";
-constexpr auto DEFAULT_ENDPOINT          = "ipc://@/malamute";
-constexpr auto CONFIG_DEFAULT_LOG_CONFIG = "/etc/fty/ftylog.cfg";
+// Public definition
+constexpr auto AGENT_NAME_KEY   = "agentName";
+constexpr auto AGENT_NAME       = "fty-config";
+constexpr auto ENDPOINT_KEY     = "endPoint";
+constexpr auto DEFAULT_ENDPOINT = "ipc://@/malamute";
+
 // Queue definition
-constexpr auto QUEUE_NAME_KEY            = "queueName";
-constexpr auto MSG_QUEUE_NAME            = "ETN.Q.IPMCORE.CONFIG";
+constexpr auto QUEUE_NAME_KEY = "queueName";
+constexpr auto MSG_QUEUE_NAME = "ETN.Q.IPMCORE.CONFIG";
+
 // Features definition
 constexpr auto MONITORING_FEATURE_NAME   = "monitoring";
 constexpr auto NOTIFICATION_FEATURE_NAME = "notification";
@@ -38,13 +39,14 @@ constexpr auto USER_SESSION_FEATURE_NAME = "user-session";
 constexpr auto DISCOVERY                 = "discovery";
 constexpr auto MASS_MANAGEMENT           = "etn-mass-management";
 constexpr auto NETWORK                   = "network";
-constexpr auto NETWORK_AGENT_SETTINGS    = "network-agent-settings";
 constexpr auto NETWORK_HOST_NAME         = "network-host-name";
+constexpr auto NETWORK_AGENT_SETTINGS    = "network-agent-settings";
 
 // Augeas definition
-constexpr auto AUGEAS_LENS_PATH          = "AugeasLensPath";
-constexpr auto AUGEAS_OPTIONS            = "augeasOptions";
+constexpr auto AUGEAS_LENS_PATH = "AugeasLensPath";
+constexpr auto AUGEAS_OPTIONS   = "augeasOptions";
+
 // Properties definition
-constexpr auto CONFIG_VERSION_KEY        = "version";
-constexpr auto ACTIVE_VERSION            = "1.0";
-constexpr auto DATA_MEMBER               = "data";
+constexpr auto CONFIG_VERSION_KEY = "version";
+constexpr auto CONFIG_VERSION     = "1.0"; //current (default)
+constexpr auto DATA_MEMBER        = "data";

--- a/src/fty_config_manager.cc
+++ b/src/fty_config_manager.cc
@@ -145,13 +145,13 @@ void ConfigurationManager::handleRequest(messagebus::Message msg)
 }
 
 // assume version X.Y formatted (major.minor)
-static bool isVersion_1_x (const std::string& v)
+static bool isVersion_1_x (const std::string& version)
 {
-    return !v.empty() && v[0] == '1';
+    return (version.find("1.") == 0);
 }
-static bool isVersion_2_x (const std::string& v)
+static bool isVersion_2_x (const std::string& version)
 {
-    return !v.empty() && v[0] == '2';
+    return (version.find("2.") == 0);
 }
 
 // data 2.x features

--- a/src/fty_config_manager.h
+++ b/src/fty_config_manager.h
@@ -66,7 +66,6 @@ private:
     void                     dumpConfiguration(std::string& path);
     std::vector<std::string> findMembersFromMatch(const std::string& input, const std::string& rootMember);
     int                      getAugeasFlags(std::string& augeasOpts);
-    bool                     isVerstionCompatible(const std::string& version);
     void                     persistValue(const std::string& fullPath, const std::string& value);
 };
 


### PR DESCRIPTION
* new data 2.0 payload format to proceed save & restore as a simple bulk file read/write action
Note: for now, only network features are saved in 2.0 format, others features always support 1.x format (augeas get/set configuration)
FrancoisRegisDegott@eaton.com